### PR TITLE
Bugfix/dep requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - restore_cache:
           name: Restore Cache
           keys:
-            - dep-packages-{{ checksum "Gopkg.lock" }}
+            - dep-packages-{{ checksum "Gopkg.lock" }}-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Install and setup
           command: make setup
@@ -46,7 +46,7 @@ jobs:
           command: make test
       - save_cache:
           name: Save Dep Cache
-          key: dep-packages-{{ checksum "Gopkg.lock" }}
+          key: dep-packages-{{ checksum "Gopkg.lock" }}-{{ .Environment.CACHE_VERSION }}
           paths:
             - vendor
             - node_modules

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ dbmate:
 clean:
 	rm -rf ./gen ./bin
 
-swagger: clean deps
+swagger: clean
 	mkdir gen
-	swagger -q generate server -t gen -f swagger/cla.yaml --exclude-main -A cla -P auth.User
+	swagger -q generate server -t gen -f swagger/cla.yaml --exclude-main -A cla -P auth.User --existing-models "github.com/LF-Engineering/lfx-kit/auth"
 
 swagger-validate:
 	swagger validate swagger/cla.yaml


### PR DESCRIPTION
- Added cache version in circleci so that we can invalidate previous cache by just changing environment variable
- Explicitly passing model path to use while generating swagger code so that even if lfx-kit auth is not present in vendor / GOPATH , still it will generate correct code.